### PR TITLE
Charbel Resslen 53924 | Firestore Migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     // Declare the dependency for the Realtime Database library
     // When using the BoM, you don't specify versions in Firebase library dependencies
     implementation 'com.google.firebase:firebase-database'
+    //Firebase Firestore
+    implementation 'com.google.firebase:firebase-firestore'
     // picasso
     implementation 'com.squareup.picasso:picasso:2.71828'
     // multidex

--- a/app/src/main/java/com/carista/SplashScreen.java
+++ b/app/src/main/java/com/carista/SplashScreen.java
@@ -11,14 +11,20 @@ import com.firebase.ui.auth.AuthUI;
 import com.firebase.ui.auth.IdpResponse;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SplashScreen extends AppCompatActivity {
     public static final int RC_SIGN_IN = 100;
     private static final int SPLASH_TIME_OUT = 3000;
-
+    private SplashScreen me=this;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -56,8 +62,26 @@ public class SplashScreen extends AppCompatActivity {
             IdpResponse response = IdpResponse.fromResultIntent(data);
 
             if (resultCode == RESULT_OK) {
-                startActivity(new Intent(this, MainActivity.class));
-                finish();
+                FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+                firestore.collection("users").whereEqualTo("id",FirebaseAuth.getInstance().getCurrentUser().getUid()).addSnapshotListener(new EventListener<QuerySnapshot>() {
+                    @Override
+                    public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                        if(value.isEmpty()){
+                            Map<String, Object> user = new HashMap<>();
+                            user.put("id",FirebaseAuth.getInstance().getCurrentUser().getUid());
+                            user.put("nickname", "Anonymous");
+                            user.put("avatar","");
+                            firestore.collection("users").add(user);
+                            startActivity(new Intent(me, MainActivity.class));
+                            finish();
+                        }
+                        else{
+                            startActivity(new Intent(me, MainActivity.class));
+                            finish();
+                        }
+                    }
+                });
+
             } else {
                 Snackbar.make(getCurrentFocus(), getString(R.string.login_error) + "\n Error code: " + response.getError().getErrorCode(), Snackbar.LENGTH_SHORT).show();
             }

--- a/app/src/main/java/com/carista/data/realtimedb/models/CommentModel.java
+++ b/app/src/main/java/com/carista/data/realtimedb/models/CommentModel.java
@@ -21,6 +21,6 @@ public class CommentModel {
     public CommentModel(Object data) {
         HashMap<String, String> _data = (HashMap<String, String>) data;
         this.comment = _data.get("comment");
-        this.user = _data.get("user");
+        this.user = _data.get("userId");
     }
 }

--- a/app/src/main/java/com/carista/photoeditor/photoeditor/EditImageActivity.java
+++ b/app/src/main/java/com/carista/photoeditor/photoeditor/EditImageActivity.java
@@ -40,6 +40,7 @@ import com.carista.photoeditor.photoeditor.filters.FilterViewAdapter;
 import com.carista.photoeditor.photoeditor.tools.EditingToolsAdapter;
 import com.carista.photoeditor.photoeditor.tools.ToolType;
 import com.carista.utils.Data;
+import com.carista.utils.FirestoreData;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseAuth;
@@ -390,7 +391,7 @@ public class EditImageActivity extends BaseActivity implements OnPhotoEditorList
                         uploadTask.addOnFailureListener(exception -> Snackbar.make(getCurrentFocus(), R.string.failed_to_upload, Snackbar.LENGTH_SHORT).show())
                                 .addOnSuccessListener(taskSnapshot -> {
                                     taskSnapshot.getMetadata().getReference().getDownloadUrl().addOnSuccessListener(uri -> {
-                                        Data.uploadPost(edittext.getText().toString().trim(), id, uri.toString(), FirebaseAuth.getInstance().getCurrentUser().getUid());
+                                        FirestoreData.uploadPost(edittext.getText().toString().trim(), id, uri.toString(), FirebaseAuth.getInstance().getCurrentUser().getUid());
                                         //mPhotoEditorView.getSource().setImageBitmap(null);
                                         edittext.setText("");
                                         Snackbar.make(getCurrentFocus(), R.string.success_upload, Snackbar.LENGTH_SHORT).show();

--- a/app/src/main/java/com/carista/ui/main/CommentsActivity.java
+++ b/app/src/main/java/com/carista/ui/main/CommentsActivity.java
@@ -1,9 +1,11 @@
 package com.carista.ui.main;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import de.hdodenhof.circleimageview.CircleImageView;
 
 import android.os.Bundle;
+import android.text.Html;
 import android.util.Log;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -11,6 +13,7 @@ import android.widget.EditText;
 import com.carista.R;
 import com.carista.data.realtimedb.models.CommentModel;
 import com.carista.utils.Data;
+import com.carista.utils.FirestoreData;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -19,6 +22,11 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.QuerySnapshot;
 import com.squareup.picasso.Picasso;
 
 public class CommentsActivity extends AppCompatActivity {
@@ -44,19 +52,15 @@ public class CommentsActivity extends AppCompatActivity {
 
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
 
-        DatabaseReference mDatabase = FirebaseDatabase.getInstance().getReference();
-        DatabaseReference userRef = mDatabase.child("/users/" + user.getUid());
-        userRef.addValueEventListener(new ValueEventListener() {
+        FirebaseFirestore firestore=FirebaseFirestore.getInstance();
+        firestore.collection("users").whereEqualTo("id", user.getUid()).addSnapshotListener(new EventListener<QuerySnapshot>() {
             @Override
-            public void onDataChange(DataSnapshot dataSnapshot) {
-                DataSnapshot avatar = dataSnapshot.child("avatar");
-                if (avatar.getValue() != null)
-                    Picasso.get().load(avatar.getValue().toString()).into(myCommentAvatar);
-            }
-            @Override
-            public void onCancelled(DatabaseError error) {
-                // Failed to read value
-                Log.w("ERROR", "Failed to read value.", error.toException());
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    String avatar = (String) documentSnapshot.get("avatar");
+                    if(!avatar.isEmpty())
+                        Picasso.get().load(avatar).into(myCommentAvatar);
+                }
             }
         });
 
@@ -67,7 +71,7 @@ public class CommentsActivity extends AppCompatActivity {
             if(comment.isEmpty())
                 return;
             CommentModel commentModel=new CommentModel(comment, FirebaseAuth.getInstance().getCurrentUser().getUid());
-            Data.addComment(postId,commentModel);
+            FirestoreData.addComment(postId,commentModel);
             myComment.setText("");
         });
 

--- a/app/src/main/java/com/carista/ui/main/fragments/CommentsRecyclerViewAdapter.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/CommentsRecyclerViewAdapter.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import com.carista.R;
 import com.carista.data.realtimedb.models.CommentModel;
 import com.carista.utils.Data;
+import com.carista.utils.FirestoreData;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,7 @@ public class CommentsRecyclerViewAdapter extends RecyclerView.Adapter<CommentsRe
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
         holder.mItem = this.items.get(position);
-        Data.setCommentAvatarNickname(holder.mItem, holder.commentAvatar, holder.commentNicknameText);
+        FirestoreData.setCommentAvatarNickname(holder.mItem, holder.commentAvatar, holder.commentNicknameText);
     }
 
     @Override

--- a/app/src/main/java/com/carista/ui/main/fragments/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/PostRecyclerViewAdapter.java
@@ -15,6 +15,7 @@ import com.carista.R;
 import com.carista.data.realtimedb.models.PostModel;
 import com.carista.ui.main.CommentsActivity;
 import com.carista.utils.Data;
+import com.carista.utils.FirestoreData;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.storage.FirebaseStorage;
@@ -54,7 +55,7 @@ public class PostRecyclerViewAdapter extends RecyclerView.Adapter<PostRecyclerVi
         imageRef.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
             @Override
             public void onSuccess(Void aVoid) {
-                Data.removePost(m.id);
+                FirestoreData.removePost(m.id);
             }
         });
         this.items.remove(position);
@@ -80,9 +81,10 @@ public class PostRecyclerViewAdapter extends RecyclerView.Adapter<PostRecyclerVi
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
         holder.mItem = this.items.get(position);
-        Data.setPostNicknameTitle(this.items.get(position).userId,this.items.get(position).title,holder.mTitleView);
-        Data.getLikesCount(this.items.get(position).id, holder.mLikeCounterView);
-        Data.isLikedByUser(this.items.get(position).id, holder.mLikeCheckbox, holder.mLikeCounterView);
+        holder.mLikeCheckbox.setChecked(false);
+        FirestoreData.setPostNicknameTitle(this.items.get(position).userId,this.items.get(position).title,holder.mTitleView);
+        FirestoreData.getLikesCount(this.items.get(position).id, holder.mLikeCounterView);
+        FirestoreData.isLikedByUser(this.items.get(position).id, holder.mLikeCheckbox, holder.mLikeCounterView);
 
         holder.mimgViewRemoveIcon.setOnClickListener(v -> {
             int position1 = holder.getAdapterPosition();
@@ -93,10 +95,10 @@ public class PostRecyclerViewAdapter extends RecyclerView.Adapter<PostRecyclerVi
         holder.mLikeCheckbox.setOnClickListener(view -> {
             int likePosition=holder.getAdapterPosition();
             if(holder.mLikeCheckbox.isChecked()){
-                Data.addLike(this.items.get(likePosition).id);
+                FirestoreData.addLike(this.items.get(likePosition).id);
             }
             else{
-                Data.removeLike(this.items.get(likePosition).id);
+                FirestoreData.removeLike(this.items.get(likePosition).id);
             }
         });
 

--- a/app/src/main/java/com/carista/ui/main/fragments/UploadFragment.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/UploadFragment.java
@@ -20,6 +20,7 @@ import android.widget.ImageView;
 
 import com.carista.R;
 import com.carista.utils.Data;
+import com.carista.utils.FirestoreData;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.storage.FirebaseStorage;
@@ -100,7 +101,7 @@ public class UploadFragment extends Fragment {
             uploadTask.addOnFailureListener(exception -> Snackbar.make(getActivity().getCurrentFocus(), R.string.failed_to_upload, Snackbar.LENGTH_SHORT).show())
                     .addOnSuccessListener(taskSnapshot -> {
                         taskSnapshot.getMetadata().getReference().getDownloadUrl().addOnSuccessListener(uri -> {
-                            Data.uploadPost(titleEditText.getText().toString().trim(), id, uri.toString(), FirebaseAuth.getInstance().getCurrentUser().getUid());
+                            FirestoreData.uploadPost(titleEditText.getText().toString().trim(), id, uri.toString(), FirebaseAuth.getInstance().getCurrentUser().getUid());
                             imageView.setImageBitmap(null);
                             titleEditText.setText("");
                             Snackbar.make(getActivity().getCurrentFocus(),R.string.success_upload,Snackbar.LENGTH_SHORT).show();

--- a/app/src/main/java/com/carista/ui/main/fragments/UserViewPagerAdapter.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/UserViewPagerAdapter.java
@@ -16,13 +16,13 @@ public class UserViewPagerAdapter extends FragmentStateAdapter {
     public Fragment createFragment(int position) {
         switch (position) {
             case 0:
-                return new UserPostsFragment();
+                return new UserPostsFragment(false);
             case 1:
-                return new UserPostsFragment();
+                return new UserPostsFragment(true);
             case 2:
                 return new UserSettingsFragment();
         }
-        return new UserPostsFragment();
+        return new UserPostsFragment(false);
     }
 
     @Override

--- a/app/src/main/java/com/carista/utils/FirestoreData.java
+++ b/app/src/main/java/com/carista/utils/FirestoreData.java
@@ -1,0 +1,230 @@
+package com.carista.utils;
+
+import android.text.Html;
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+import com.carista.data.realtimedb.models.CommentModel;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.SetOptions;
+import com.squareup.picasso.Picasso;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import de.hdodenhof.circleimageview.CircleImageView;
+
+public class FirestoreData {
+    public static void uploadPost(String title, long id, String imageURL, String userId){
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        Map<String, Object> post = new HashMap<>();
+
+        post.put("id",String.valueOf(id));
+        post.put("title", title);
+        post.put("image", imageURL);
+        post.put("userId",userId);
+        post.put("likes",new ArrayList<String>());
+        post.put("comments",new ArrayList<HashMap<String,Object>>());
+        post.put("timestamp", new java.util.Date().getTime());
+
+        firestore.collection("posts").add(post);
+    }
+
+    public static void uploadAvatarLink(String avatarURL) {
+        FirebaseFirestore firestore=FirebaseFirestore.getInstance();
+        firestore.collection("users").whereEqualTo("id", FirebaseAuth.getInstance().getCurrentUser().getUid()).addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    Map<String, Object> updates = new HashMap<>();
+                    updates.put("avatar",avatarURL);
+                    firestore.collection("users").document(documentSnapshot.getId()).update(updates);
+                    break;
+                }
+            }
+        });
+    }
+
+    public static void uploadNickname(String nickname) {
+        FirebaseFirestore firestore=FirebaseFirestore.getInstance();
+        firestore.collection("users").whereEqualTo("id", FirebaseAuth.getInstance().getCurrentUser().getUid()).addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    Map<String, Object> updates = new HashMap<>();
+                    updates.put("nickname",nickname);
+                    firestore.collection("users").document(documentSnapshot.getId()).update(updates);
+                    break;
+                }
+            }
+        });
+    }
+
+    public static void addLike(String postId){
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        firestore.collection("posts").whereEqualTo("id", postId).get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+            @Override
+            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                if(task.isSuccessful()){
+                    for(QueryDocumentSnapshot documentSnapshot: task.getResult()){
+                        ArrayList<String> likes = (ArrayList<String>) documentSnapshot.get("likes");
+                        likes.add(FirebaseAuth.getInstance().getCurrentUser().getUid());
+                        Map<String, Object> updates = new HashMap<>();
+                        updates.put("likes",likes);
+                        firestore.collection("posts").document(documentSnapshot.getId()).update(updates);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    public static void addComment(String postId, CommentModel commentModel){
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        firestore.collection("posts").whereEqualTo("id", postId).get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+            @Override
+            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                if(task.isSuccessful()){
+                    for(QueryDocumentSnapshot documentSnapshot: task.getResult()){
+                        ArrayList<HashMap<String,Object>> comments = (ArrayList<HashMap<String, Object>>) documentSnapshot.get("comments");
+
+                        HashMap<String,Object> newComment = new HashMap<>();
+                        newComment.put("userId",commentModel.user);
+                        newComment.put("comment",commentModel.comment);
+                        comments.add(newComment);
+
+                        Map<String, Object> updates = new HashMap<>();
+                        updates.put("comments",comments);
+                        firestore.collection("posts").document(documentSnapshot.getId()).update(updates);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    public static void getLikesCount(String postId, TextView view){
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        firestore.collection("posts").whereEqualTo("id", postId).addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    ArrayList<String> likes = (ArrayList<String>) documentSnapshot.get("likes");
+                    if(likes.size()>1){
+                        if(likes.contains(FirebaseAuth.getInstance().getCurrentUser().getUid()))
+                            view.setText("You and "+(likes.size()-1)+" others like this");
+                        else
+                            view.setText(likes.size()+" likes");
+                    }
+                    else{
+                        if(likes.contains(FirebaseAuth.getInstance().getCurrentUser().getUid()))
+                            view.setText("Only you like this");
+                        else
+                            view.setText(likes.size()+" likes");
+                    }
+                    break;
+                }
+            }
+        });
+    }
+
+    public static void setCommentAvatarNickname(CommentModel commentModel, CircleImageView userAvatar, TextView userNicknameText){
+        FirebaseFirestore firestore=FirebaseFirestore.getInstance();
+        firestore.collection("users").whereEqualTo("id", commentModel.user).addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    String nickname= (String) documentSnapshot.get("nickname");
+                    String avatar = (String) documentSnapshot.get("avatar");
+                    if(!avatar.isEmpty())
+                        Picasso.get().load(avatar).into(userAvatar);
+                    userNicknameText.setText(Html.fromHtml("<b>"+nickname+"</b> "+commentModel.comment));
+                }
+            }
+        });
+    }
+
+    public static void setPostNicknameTitle(String user, String title, TextView userNicknameTitle){
+        FirebaseFirestore firestore=FirebaseFirestore.getInstance();
+        firestore.collection("users").whereEqualTo("id", FirebaseAuth.getInstance().getCurrentUser().getUid()).addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    String nickname= (String) documentSnapshot.get("nickname");
+                    userNicknameTitle.setText(Html.fromHtml("<b>"+nickname+"</b> "+title));
+                }
+            }
+        });
+    }
+
+    public static void isLikedByUser(String postId, CheckBox view, TextView view1){
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        firestore.collection("posts").whereEqualTo("id", postId).addSnapshotListener(new EventListener<QuerySnapshot>() {
+            @Override
+            public void onEvent(@Nullable QuerySnapshot value, @Nullable FirebaseFirestoreException error) {
+                for(DocumentSnapshot documentSnapshot: value.getDocuments()){
+                    ArrayList<String> likes = (ArrayList<String>) documentSnapshot.get("likes");
+                    if(likes.contains(FirebaseAuth.getInstance().getCurrentUser().getUid())){
+                        view.setChecked(true);
+                        if(likes.size()>1)
+                            view1.setText("You and "+(likes.size()-1)+" others like this");
+                        else
+                            view1.setText("Only you like this");
+                    }
+                    else
+                        view.setChecked(false);
+                    break;
+                }
+            }
+        });
+    }
+
+    public static void removeLike(String postId){
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        firestore.collection("posts").whereEqualTo("id", postId).get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+            @Override
+            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                if(task.isSuccessful()){
+                    for(QueryDocumentSnapshot documentSnapshot: task.getResult()){
+                        ArrayList<String> likes = (ArrayList<String>) documentSnapshot.get("likes");
+                        likes.remove(FirebaseAuth.getInstance().getCurrentUser().getUid());
+                        Map<String, Object> updates = new HashMap<>();
+                        updates.put("likes",likes);
+                        firestore.collection("posts").document(documentSnapshot.getId()).update(updates);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    public static void removePost(String id) {
+        FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+        firestore.collection("posts").whereEqualTo("id", id).get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+            @Override
+            public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                if(task.isSuccessful()){
+                    for(QueryDocumentSnapshot documentSnapshot: task.getResult()){
+                        String userId=String.valueOf(documentSnapshot.get("userId"));
+                        if(userId.equals(FirebaseAuth.getInstance().getCurrentUser().getUid()))
+                            firestore.collection("posts").document(documentSnapshot.getId()).delete();
+                        break;
+                    }
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
### **Abstract**

Due to some lack in handy tools, we decided to migrate the entire application database system from the **Firebase Real-Time Database** to **Firebase Cloud Firestore**. The main difference lies within the inner structure organization, as both deal with JSON Objects and HashMaps, but the positive points in Cloud Firestore are that it provides a clean Collection-Document structure, extra methods to manipulate queries, and better compatibility with Java Data Structures (ArrayLists, Maps, Strings, ...).

At this point, it's less code and complexity without losing the Real-Time capability that the old system used to have.


### **Features**

- Created a new **Cloud Firestore Database** with 2 **Collections**. **Documents** go inside collections accordingly.

> Pretty much the same design. Comments are now _ArrayLists_ of _HashMaps_ containing **UserIDs** and **Comment Texts**.

> Likes are now an _ArrayList_ containing **UserIDs** only. Got rid of auto-generated IDs when pushing new values to the old database system.

> Users now have a default nickname "Anonymous" when not having a custom nickname.

- Created a helper class **FirestoreData** to update the old functions in order to migrate easier and leave the **Data** utility class for future reference.

> Absolutely migrated and mapped everything from a stable to another stable **Firebase Database** system without losing Real-Time functionalities

> This new class ensures that, at any point of time, we are capable of recovering the old system's database utilities.

- Switched helper classes from **Data** to **FirestoreData** in all **RecyclerViewAdapaters** and **Fragments**.

> Not to mention the **RecyclerViewAdapters** population code has also changed in all the Fragments that contain a **RecyclerView**.

- Added User Liked Posts to its missing tab in the User Tab.

> Instead of creating a new fragment, passed a _boolean_ variable to the regular **UserPostsFragment** to check if we display the User Posts or User Liked Posts, and assigned tabs accordingly.

- Added lazy loading and manual refreshing.

> Implementing a lazy loading costs the life of the Real-Time mechanism. So, we implemented a manual refresh mechanism to refresh posts in case new ones are uploaded.

> On the other hand, implementing it helps remove the picture-size changing bug as it is replicated using Real-Time loading. Same goes for the animation of the like button, and both were automatically fixed as a result of migration.

> Posts load 5 by 5 in a descending order of timestamp (newest to oldest).

> End of list scrolling automatically loads the next 5 posts.  

> Pulling upwards when the top of list is reached auto-refreshes the list.

