### PR TITLE
Charbel Resslen 53924 | Firebase Migration to Cloud Firestore

### DIFF
--- a/app/src/main/java/com/carista/ui/main/fragments/PostFragment.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/PostFragment.java
@@ -124,7 +124,7 @@ public class PostFragment extends Fragment {
                     }
                 }
 
-                if(!recyclerView.canScrollVertically(-1) && recyclerView.canScrollVertically(1)){
+                if(!recyclerView.canScrollVertically(-1)){
                     FirebaseFirestore firestore = FirebaseFirestore.getInstance();
                     firestore.collection("posts").orderBy("timestamp", Query.Direction.DESCENDING).limit(5).get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
                         @Override

--- a/app/src/main/java/com/carista/ui/main/fragments/PostRecyclerViewAdapter.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/PostRecyclerViewAdapter.java
@@ -5,6 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -73,10 +74,17 @@ public class PostRecyclerViewAdapter extends RecyclerView.Adapter<PostRecyclerVi
     @Override
     public void onBindViewHolder(final ViewHolder holder, int position) {
         holder.mItem = this.items.get(position);
-        holder.mLikeCheckbox.setChecked(false);
+
         FirestoreData.setPostNicknameTitle(this.items.get(position).userId, this.items.get(position).title, holder.mTitleView);
         FirestoreData.getLikesCount(this.items.get(position).id, holder.mLikeCounterView);
         FirestoreData.isLikedByUser(this.items.get(position).id, holder.mLikeCheckbox, holder.mLikeCounterView);
+
+        holder.mLikeCheckbox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+
+            }
+        });
 
         holder.mimgViewRemoveIcon.setOnClickListener(v -> {
             int position1 = holder.getAdapterPosition();
@@ -127,6 +135,7 @@ public class PostRecyclerViewAdapter extends RecyclerView.Adapter<PostRecyclerVi
             mLikeCheckbox = view.findViewById(R.id.like_checkbox);
             mLikeCounterView = view.findViewById(R.id.likes_counter);
             mCommentCheckbox = view.findViewById(R.id.comment_checkbox);
+            this.setIsRecyclable(false);
         }
     }
 

--- a/app/src/main/java/com/carista/ui/main/fragments/UserPostsFragment.java
+++ b/app/src/main/java/com/carista/ui/main/fragments/UserPostsFragment.java
@@ -29,11 +29,11 @@ public class UserPostsFragment extends Fragment {
     private boolean isUserLikesOnly;
 
     public UserPostsFragment() {
-
+        // Required empty public constructor
     }
 
     public UserPostsFragment(boolean isUserLikesOnly) {
-        // Required empty public constructor
+
         this.isUserLikesOnly = isUserLikesOnly;
     }
 

--- a/app/src/main/java/com/carista/utils/FirestoreData.java
+++ b/app/src/main/java/com/carista/utils/FirestoreData.java
@@ -2,6 +2,7 @@ package com.carista.utils;
 
 import android.text.Html;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -174,6 +175,7 @@ public class FirestoreData {
                             view1.setText(R.string.only_you_like_this);
                     } else
                         view.setChecked(false);
+
                     break;
                 }
             }


### PR DESCRIPTION
### **Abstract**

Due to some lack in handy tools, we decided to migrate the entire application database system from the **Firebase Real-Time Database** to **Firebase Cloud Firestore**. The main difference lies within the inner structure organization, as both deal with JSON Objects and HashMaps, but the positive points in Cloud Firestore are that it provides a clean Collection-Document structure, extra methods to manipulate queries, and better compatibility with Java Data Structures (ArrayLists, Maps, Strings, ...).

At this point, it's less code and complexity without losing the Real-Time capability that the old system used to have.


### **Features**

- Created a new **Cloud Firestore Database** with 2 **Collections**. **Documents** go inside collections accordingly.

> Pretty much the same design. Comments are now _ArrayLists_ of _HashMaps_ containing **UserIDs** and **Comment Texts**.

> Likes are now an _ArrayList_ containing **UserIDs** only. Got rid of auto-generated IDs when pushing new values to the old database system.

> Users now have a default nickname "Anonymous" when not having a custom nickname.

- Created a helper class **FirestoreData** to update the old functions in order to migrate easier and leave the **Data** utility class for future reference.

> Absolutely migrated and mapped everything from a stable to another stable **Firebase Database** system without losing Real-Time functionalities

> This new class ensures that, at any point of time, we are capable of recovering the old system's database utilities.

- Switched helper classes from **Data** to **FirestoreData** in all **RecyclerViewAdapaters** and **Fragments**.

> Not to mention the **RecyclerViewAdapters** population code has also changed in all the Fragments that contain a **RecyclerView**.

- Added User Liked Posts to its missing tab in the User Tab.

> Instead of creating a new fragment, passed a _boolean_ variable to the regular **UserPostsFragment** to check if we display the User Posts or User Liked Posts, and assigned tabs accordingly.

- Added lazy loading and manual refreshing.

> Implementing a lazy loading costs the life of the Real-Time mechanism. So, we implemented a manual refresh mechanism to refresh posts in case new ones are uploaded.

> On the other hand, implementing it helps remove the picture-size changing bug as it is replicated using Real-Time loading. Same goes for the animation of the like button, and both were automatically fixed as a result of migration.

> Posts load 5 by 5 in a descending order of timestamp (newest to oldest).

> End of list scrolling automatically loads the next 5 posts.  

> Pulling upwards when the top of list is reached auto-refreshes the list.

